### PR TITLE
Fix warnings on GCC 7.2.0

### DIFF
--- a/include/CommonAPI/DBus/DBusEvent.hpp
+++ b/include/CommonAPI/DBus/DBusEvent.hpp
@@ -155,7 +155,7 @@ public:
         std::get<3>(subscription_) = "";
     }
 
-    template<int ... Indices_>
+    template<std::size_t ... Indices_>
     inline void handleSignalDBusMessage(const DBusMessage &_message, index_sequence<Indices_...>) {
         DBusInputStream input(_message);
         if (DBusSerializableArguments<
@@ -165,7 +165,7 @@ public:
         }
     }
 
-    template<int ... Indices_>
+    template<std::size_t ... Indices_>
     inline void handleSignalDBusMessage(const uint32_t tag, const DBusMessage &_message, index_sequence<Indices_...>) {
         DBusInputStream input(_message);
         if (DBusSerializableArguments<

--- a/include/CommonAPI/DBus/DBusHelper.hpp
+++ b/include/CommonAPI/DBus/DBusHelper.hpp
@@ -16,23 +16,23 @@
 namespace CommonAPI {
 namespace DBus {
 
-template <int ...>
+template <std::size_t ...>
 struct index_sequence {};
 
 
-template <int N_, int ...S_>
+template <std::size_t N_, std::size_t ...S_>
 struct make_sequence : make_sequence<N_-1, N_-1, S_...> {};
 
-template <int ...S_>
+template <std::size_t ...S_>
 struct make_sequence<0, S_...> {
     typedef index_sequence<S_...> type;
 };
 
 
-template <int N_, int Offset_, int ...S_>
+template <std::size_t N_, std::size_t Offset_, std::size_t ...S_>
 struct make_sequence_range : make_sequence_range<N_-1, Offset_, N_-1+Offset_, S_...> {};
 
-template <int Offset_, int ...S_>
+template <std::size_t Offset_, std::size_t ...S_>
 struct make_sequence_range<0, Offset_, S_...> {
     typedef index_sequence<S_...> type;
 };

--- a/include/CommonAPI/DBus/DBusProxyAsyncCallbackHandler.hpp
+++ b/include/CommonAPI/DBus/DBusProxyAsyncCallbackHandler.hpp
@@ -119,7 +119,7 @@ class DBusProxyAsyncCallbackHandler :
     std::tuple<ArgTypes_...> args_;
 
  private:
-    template <int... ArgIndices_>
+    template <std::size_t... ArgIndices_>
     inline CallStatus handleDBusMessageReply(
             const CallStatus _dbusMessageCallStatus,
             const DBusMessage& _dbusMessage,


### PR DESCRIPTION
This fixes an warning about implicit conversion from std::size_t (long
unsigned int) to int as operator sizeof() returns std::size_t