### PR TITLE
cmake: Modernize exported CMake config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,27 +132,10 @@ message(STATUS "CommonAPI_CONSIDERED_CONFIGS: ${CommonAPI_CONSIDERED_CONFIGS}")
 message(STATUS "COMMONAPI_INCLUDE_DIRS: ${COMMONAPI_INCLUDE_DIRS}")
 message(STATUS "CommonAPI Version: ${CommonAPI_VERSION}")
 
-###############################################################################
-# find DBus by using the 'pkg-config' tool
-if (MSVC)
-    #Not beautiful, but it works
-    if (DBus_DIR)
-        if (DBus_BUILD_DIR)
-            set(DBus_INCLUDE_DIRS "${DBus_DIR};${DBus_BUILD_DIR};")
-            set(DBus_LIBRARY_RELEASE "${DBus_BUILD_DIR}/bin/Release/dbus-1.lib")
-            set(DBus_LIBRARY_DEBUG "${DBus_BUILD_DIR}/bin/Debug/dbus-1d.lib")
-        endif()
-    endif()
-
-    if (NOT DBus_LIBRARIES)
-        include(SelectLibraryConfigurations)
-        select_library_configurations(DBus)
-    endif()
-    if (NOT DBus_INCLUDE_DIRS OR NOT DBus_LIBRARIES)
-      message(SEND_ERROR "Set DBus_INCLUDE_DIRS and DBus_LIBRARIES to your D-Bus installation (e.g. cmake -DDBus_INCLUDE_DIRS=C:\\D-Bus\\include -DDBus_LIBRARIES=C:\\DBus\\lib\\dbus-1.lib")
-    endif()
+if ("${USE_INSTALLED_DBUS}" STREQUAL "ON")
+    FIND_PACKAGE(DBus1 1.4 REQUIRED CONFIG NO_CMAKE_PACKAGE_REGISTRY)
 else()
-    pkg_check_modules(DBus REQUIRED dbus-1>=1.4)
+    FIND_PACKAGE(DBus1 1.4 REQUIRED CONFIG NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
 endif()
 
 ##############################################################################
@@ -174,19 +157,7 @@ message(STATUS "Compiler options: ${CMAKE_CXX_FLAGS}")
 include_directories(
     include
     ${COMMONAPI_INCLUDE_DIRS}
-    ${DBus_INCLUDE_DIRS}
 )
-
-if ("${USE_INSTALLED_DBUS}" STREQUAL "ON")
-    link_directories(
-        ${DBus_LIBRARY_DIRS}
-    )
-else()
-    set (DBus_LIBRARIES dbus-1)
-    link_directories(
-        ${DBus_INCLUDE_DIRS}/dbus/.libs
-    )
-endif()
 
 # DBus source files
 file(GLOB CAPIDB_SRCS "src/CommonAPI/DBus/*.cpp")
@@ -202,14 +173,19 @@ list(SORT MMHASH_SRCS)
 
 # CommonAPI-DBus library
 add_library(CommonAPI-DBus SHARED ${CAPIDB_SRCS} ${PUGIXML_SRCS} ${MMHASH_SRCS})
-
-target_link_libraries(CommonAPI-DBus CommonAPI ${DBus_LIBRARIES})
+target_include_directories(CommonAPI-DBus INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>)
+target_link_libraries(CommonAPI-DBus PUBLIC CommonAPI dbus-1)
 
 if (MSVC)
     target_link_libraries(CommonAPI-DBus ws2_32 Rpcrt4)
 endif()
 
-set_target_properties(CommonAPI-DBus PROPERTIES VERSION ${LIBCOMMONAPI_DBUS_MAJOR_VERSION}.${LIBCOMMONAPI_DBUS_MINOR_VERSION}.${LIBCOMMONAPI_DBUS_PATCH_VERSION} SOVERSION ${LIBCOMMONAPI_DBUS_MAJOR_VERSION}.${LIBCOMMONAPI_DBUS_MINOR_VERSION}.${LIBCOMMONAPI_DBUS_PATCH_VERSION} LINKER_LANGUAGE C)
+set_target_properties(CommonAPI-DBus PROPERTIES
+    VERSION ${LIBCOMMONAPI_DBUS_MAJOR_VERSION}.${LIBCOMMONAPI_DBUS_MINOR_VERSION}.${LIBCOMMONAPI_DBUS_PATCH_VERSION}
+    SOVERSION ${LIBCOMMONAPI_DBUS_MAJOR_VERSION}.${LIBCOMMONAPI_DBUS_MINOR_VERSION}.${LIBCOMMONAPI_DBUS_PATCH_VERSION}
+    LINKER_LANGUAGE C)
 
 ##############################################################################
 
@@ -250,25 +226,14 @@ export(TARGETS CommonAPI-DBus
 export(PACKAGE CommonAPI-DBus)
 
 # Create the CommonAPI-DBusConfig.cmake and CommonAPI-DBusConfigVersion files ...
-file(RELATIVE_PATH REL_INCLUDE_DIR "${ABSOLUTE_INSTALL_CMAKE_DIR}" "${ABSOLUTE_INSTALL_INCLUDE_DIR}")
-
-# ... for the build tree
-set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CommonAPI-DBusConfig.cmake.in
   "${PROJECT_BINARY_DIR}/CommonAPI-DBusConfig.cmake" @ONLY)
-
-# ... for the install tree
-set(CONF_INCLUDE_DIRS "\${COMMONAPI_DBUS_CMAKE_DIR}/${REL_INCLUDE_DIR}")
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CommonAPI-DBusConfig.cmake.in
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CommonAPI-DBusConfig.cmake" @ONLY)
-
-# ... for both
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CommonAPI-DBusConfigVersion.cmake.in
   "${PROJECT_BINARY_DIR}/CommonAPI-DBusConfigVersion.cmake" @ONLY)
 
 # Install the CommonAPI-DBusConfig.cmake and CommonAPI-DBusConfigVersion.cmake
 install(FILES
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CommonAPI-DBusConfig.cmake"
+  "${PROJECT_BINARY_DIR}/CommonAPI-DBusConfig.cmake"
   "${PROJECT_BINARY_DIR}/CommonAPI-DBusConfigVersion.cmake"
   DESTINATION "${INSTALL_CMAKE_DIR}")
 

--- a/cmake/CommonAPI-DBusConfig.cmake.in
+++ b/cmake/CommonAPI-DBusConfig.cmake.in
@@ -1,13 +1,26 @@
 # - Config file for the CommonAPI-DBus package
-# It defines the following variables
-#  COMMONAPI_DBUS_INCLUDE_DIRS - include directories for CommonAPI-DBus
+# Exports the following targets:
+#   CommonAPI-DBus - CMake target for CommonAPI DBus
+# Additionally, the following variables are defined:
+#   COMMONAPI_DBUS_VERSION - The CommonAPI-DBus version number
+
+# Dependencies
+include(CMakeFindDependencyMacro)
+find_dependency(CommonAPI)
+
+if(NOT TARGET dbus-1)
+    # the DBus1 CMake config is not double-include safe
+    find_dependency(DBus1)
+endif()
 
 # Compute paths
 get_filename_component(COMMONAPI_DBUS_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(COMMONAPI_DBUS_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
 
 # Our library dependencies (contains definitions for IMPORTED targets)
 include("${COMMONAPI_DBUS_CMAKE_DIR}/CommonAPI-DBusTargets.cmake")
+
+# Legacy variable, kept for compatibility
+get_target_property(COMMONAPI_DBUS_INCLUDE_DIRS CommonAPI-DBus INTERFACE_INCLUDE_DIRECTORIES)
 
 set(COMMONAPI_DBUS_VERSION @PACKAGE_VERSION@)
 set(COMMONAPI_DBUS_VERSION_STRING "@PACKAGE_VERSION@")

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -11,17 +11,9 @@ include_directories(.
        ./src-gen/core
        ./src-gen/dbus
        ${COMMONAPI_INCLUDE_DIRS}
-       ${DBus_INCLUDE_DIRS}
        ${gtest_SOURCE_DIR}/include
        ${GLIB_INCLUDE_DIRS}
 )
-
-if ("${USE_INSTALLED_DBUS}" STREQUAL "OFF")
-    set(DBus_LDFLAGS dbus-1)
-    link_directories(
-        ${DBus_INCLUDE_DIRS}/dbus/.libs
-    )
-endif()
 
 set(VERSION "v1")
 
@@ -71,9 +63,9 @@ set(ExtendedInterfaceDBusSources ${ExtendedInterfaceSources}
                                  src-gen/dbus/${VERSION}/commonapi/tests/ExtendedInterfaceDBusStubAdapter.cpp)
 
 if (MSVC)
- set(TEST_LINK_LIBRARIES ${DBus_LDFLAGS} CommonAPI-DBus CommonAPI gtest )
+ set(TEST_LINK_LIBRARIES CommonAPI-DBus CommonAPI gtest )
 else()
- set(TEST_LINK_LIBRARIES -Wl,--no-as-needed CommonAPI-DBus -Wl,--as-needed CommonAPI ${DBus_LDFLAGS} ${DL_LIBRARY} gtest ${PTHREAD_LIBRARY})
+ set(TEST_LINK_LIBRARIES -Wl,--no-as-needed CommonAPI-DBus -Wl,--as-needed CommonAPI ${DL_LIBRARY} gtest ${PTHREAD_LIBRARY})
 endif()
 
 ##############################################################################


### PR DESCRIPTION
The CMake configuration files exported by CommonAPI-DBus require users to add the `${COMMONAPI_DBUS_INCLUDE_DIRS}` variable to their project's include directories. This was done to support building against a build tree of CommonAPI-DBus by generating two different
`CommonAPI-DBusConfig.cmake` files that defined this variable with different values.

This is now no longer necessary since CMake supports the `$<BUILD_INTERFACE>` and `$<INSTALL_INTERFACE>` generator expressions which can be used to make the same distinction with only a single `CommonAPI-DBusConfig.cmake` file.

This also allows users of CommonAPI-DBus to get the required include directories into their build by using
```cmake
target_link_libraries(${target} CommonAPI-DBus)
```
since the exported CommonAPI-DBus CMake target now has the required include directories set as a property. This is much more idiomatic for users of CMake and is thus preferred.

Additionally, the exported target required users to manually find a copy of DBus and link against DBus as well as against CommonAPI-DBus rather than automatically locating the DBus dependency. Modify the target to also do this step automatically so that users of CommonAPI-DBus only
need to care about the CommonAPI-DBus CMake target.

This enables downstream projects that build CommonAPI interface libraries to no longer care about what the CommonAPI-DBus include directories are, which simplifies writing CMake config files for them.

I've locally compiled vSomeIP, CommonAPI, CommonAPI-SomeIP and a test project using CommonAPI-SomeIP to test this. I would have done the same for CommonAPI-DBus, but unfortunately this state of capicxx-dbus-runtime does not compile against my system's DBus headers, so I couldn't test this. Since the change is basically the same as in the other PRs, I don't expect any problems. Additionally, I will perform testing on these changes in an internal project and report if I encounter any problems.