### PR TITLE
capicxx-dbus-runtime 3.2.3-r1

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,15 +1,25 @@
 Changes
 =======
 
+v3.2.3
+- Fixed crash in dbus_message_set_reply_serial()
+- Update the object cache on the result of getManagedObjectsAsync
+
+v3.2.2
+- Adapt to CommonAPI v3.2.2
+
+v3.2.1
+- Fix float array serialization
+
 v3.2.0
-- adapt to CommonAPI v3.2.0
+- Adapt to CommonAPI v3.2.0
 
 v3.1.12.4
-- support 'lock functors' in AttributeDispatcher(s)
+- Support 'lock functors' in AttributeDispatcher(s)
 
 v3.1.12.3
 - Fixed data race in generated StubDefault when using attributes
-- use eventfd instead of pipe in Watch
+- Use eventfd instead of pipe in Watch
 
 v3.1.12.2
 - Fixed hang-up in proxy destruction when async method call was done and proxy is not available

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ PROJECT(libcommonapi-dbus)
 # version of CommonAPI-DBus
 SET( LIBCOMMONAPI_DBUS_MAJOR_VERSION 3 )
 SET( LIBCOMMONAPI_DBUS_MINOR_VERSION 2 )
-SET( LIBCOMMONAPI_DBUS_PATCH_VERSION 0 )
+SET( LIBCOMMONAPI_DBUS_PATCH_VERSION 3 )
 
 message(STATUS "Project name: ${PROJECT_NAME}")
 
@@ -127,9 +127,9 @@ message(STATUS "CMAKE_FIND_ROOT_PATH: ${CMAKE_FIND_ROOT_PATH}")
 FIND_PACKAGE(PkgConfig)
 FIND_PACKAGE(Threads REQUIRED)
 if ("${USE_INSTALLED_COMMONAPI}" STREQUAL "ON")
-    FIND_PACKAGE(CommonAPI 3.2.0 REQUIRED CONFIG NO_CMAKE_PACKAGE_REGISTRY)
+    FIND_PACKAGE(CommonAPI 3.2 REQUIRED CONFIG NO_CMAKE_PACKAGE_REGISTRY)
 else()
-    FIND_PACKAGE(CommonAPI 3.2.0 REQUIRED CONFIG NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+    FIND_PACKAGE(CommonAPI 3.2 REQUIRED CONFIG NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
 endif()
 
 message(STATUS "CommonAPI_CONSIDERED_CONFIGS: ${CommonAPI_CONSIDERED_CONFIGS}")
@@ -156,7 +156,11 @@ if (MSVC)
       message(SEND_ERROR "Set DBus_INCLUDE_DIRS and DBus_LIBRARIES to your D-Bus installation (e.g. cmake -DDBus_INCLUDE_DIRS=C:\\D-Bus\\include -DDBus_LIBRARIES=C:\\DBus\\lib\\dbus-1.lib")
     endif()
 else()
-    pkg_check_modules(DBus REQUIRED dbus-1>=1.4)
+    if ("${USE_INSTALLED_DBUS}" STREQUAL "ON")
+        FIND_PACKAGE(DBus1 1.4 REQUIRED CONFIG NO_CMAKE_PACKAGE_REGISTRY)
+    else()
+        FIND_PACKAGE(DBus1 1.4 REQUIRED CONFIG NO_SYSTEM_ENVIRONMENT_PATH NO_CMAKE_SYSTEM_PATH)
+    endif()
 endif()
 
 ##############################################################################
@@ -168,7 +172,7 @@ if (MSVC)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -D_CRT_SECURE_NO_WARNINGS -DCOMMONAPI_INTERNAL_COMPILATION -DCOMMONAPI_DLL_COMPILATION /EHsc /wd4503")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_CRT_SECURE_NO_WARNINGS -DCOMMONAPI_INTERNAL_COMPILATION -DCOMMONAPI_DLL_COMPILATION /wd4503")
 else()
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wformat -Wformat-security -Wconversion -fexceptions -fstrict-aliasing -fstack-protector -fasynchronous-unwind-tables -fno-omit-frame-pointer -DCOMMONAPI_INTERNAL_COMPILATION -D_GLIBCXX_USE_NANOSLEEP -fvisibility=hidden")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra -Wformat -Wformat-security -fexceptions -fstrict-aliasing -fstack-protector -fasynchronous-unwind-tables -fno-omit-frame-pointer -DCOMMONAPI_INTERNAL_COMPILATION -D_GLIBCXX_USE_NANOSLEEP -fvisibility=hidden")
 endif()
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCOMMONAPI_LOGLEVEL=COMMONAPI_LOGLEVEL_${MAX_LOG_LEVEL}")
@@ -178,19 +182,7 @@ message(STATUS "Compiler options: ${CMAKE_CXX_FLAGS}")
 include_directories(
     include
     ${COMMONAPI_INCLUDE_DIRS}
-    ${DBus_INCLUDE_DIRS}
 )
-
-if ("${USE_INSTALLED_DBUS}" STREQUAL "ON")
-    link_directories(
-        ${DBus_LIBRARY_DIRS}
-    )
-else()
-    set (DBus_LIBRARIES dbus-1)
-    link_directories(
-        ${DBus_INCLUDE_DIRS}/dbus/.libs
-    )
-endif()
 
 # DBus source files
 file(GLOB CAPIDB_SRCS "src/CommonAPI/DBus/*.cpp")
@@ -206,14 +198,19 @@ list(SORT MMHASH_SRCS)
 
 # CommonAPI-DBus library
 add_library(CommonAPI-DBus SHARED ${CAPIDB_SRCS} ${PUGIXML_SRCS} ${MMHASH_SRCS})
-
-target_link_libraries(CommonAPI-DBus CommonAPI ${DBus_LIBRARIES})
+target_include_directories(CommonAPI-DBus INTERFACE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${INSTALL_INCLUDE_DIR}>)
+target_link_libraries(CommonAPI-DBus PUBLIC CommonAPI dbus-1)
 
 if (MSVC)
     target_link_libraries(CommonAPI-DBus ws2_32 Rpcrt4)
 endif()
 
-set_target_properties(CommonAPI-DBus PROPERTIES VERSION ${LIBCOMMONAPI_DBUS_MAJOR_VERSION}.${LIBCOMMONAPI_DBUS_MINOR_VERSION}.${LIBCOMMONAPI_DBUS_PATCH_VERSION} SOVERSION ${LIBCOMMONAPI_DBUS_MAJOR_VERSION}.${LIBCOMMONAPI_DBUS_MINOR_VERSION}.${LIBCOMMONAPI_DBUS_PATCH_VERSION} LINKER_LANGUAGE C)
+set_target_properties(CommonAPI-DBus PROPERTIES
+    VERSION ${LIBCOMMONAPI_DBUS_MAJOR_VERSION}.${LIBCOMMONAPI_DBUS_MINOR_VERSION}.${LIBCOMMONAPI_DBUS_PATCH_VERSION}
+    SOVERSION ${LIBCOMMONAPI_DBUS_MAJOR_VERSION}.${LIBCOMMONAPI_DBUS_MINOR_VERSION}.${LIBCOMMONAPI_DBUS_PATCH_VERSION}
+    LINKER_LANGUAGE C)
 
 ##############################################################################
 
@@ -254,25 +251,14 @@ export(TARGETS CommonAPI-DBus
 export(PACKAGE CommonAPI-DBus)
 
 # Create the CommonAPI-DBusConfig.cmake and CommonAPI-DBusConfigVersion files ...
-file(RELATIVE_PATH REL_INCLUDE_DIR "${ABSOLUTE_INSTALL_CMAKE_DIR}" "${ABSOLUTE_INSTALL_INCLUDE_DIR}")
-
-# ... for the build tree
-set(CONF_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/include")
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CommonAPI-DBusConfig.cmake.in
   "${PROJECT_BINARY_DIR}/CommonAPI-DBusConfig.cmake" @ONLY)
-
-# ... for the install tree
-set(CONF_INCLUDE_DIRS "\${COMMONAPI_DBUS_CMAKE_DIR}/${REL_INCLUDE_DIR}")
-configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CommonAPI-DBusConfig.cmake.in
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CommonAPI-DBusConfig.cmake" @ONLY)
-
-# ... for both
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CommonAPI-DBusConfigVersion.cmake.in
   "${PROJECT_BINARY_DIR}/CommonAPI-DBusConfigVersion.cmake" @ONLY)
 
 # Install the CommonAPI-DBusConfig.cmake and CommonAPI-DBusConfigVersion.cmake
 install(FILES
-  "${PROJECT_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CommonAPI-DBusConfig.cmake"
+  "${PROJECT_BINARY_DIR}/CommonAPI-DBusConfig.cmake"
   "${PROJECT_BINARY_DIR}/CommonAPI-DBusConfigVersion.cmake"
   DESTINATION "${INSTALL_CMAKE_DIR}")
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 ### CommonAPI C++ D-Bus Runtime
 
 ##### Copyright
-Copyright (C) 2016-2017, Bayerische Motoren Werke Aktiengesellschaft (BMW AG).
-Copyright (C) 2016-2017, GENIVI Alliance, Inc.
+Copyright (C) 2016-2023, Bayerische Motoren Werke Aktiengesellschaft (BMW AG).
+Copyright (C) 2016-2023, COVESA
 
-This file is part of GENIVI Project IPC Common API C++.
-Contributions are licensed to the GENIVI Alliance under one or more Contribution License Agreements or MPL 2.0.
+This file is part of COVESA Project IPC Common API C++.
+Contributions are licensed to the COVESA under one or more Contribution License Agreements or MPL 2.0.
 
 ##### License
 This Source Code Form is subject to the terms of the Mozilla Public License, v. 2.0. If a copy of the MPL was not distributed with this file, you can obtain one at http://mozilla.org/MPL/2.0/.
@@ -14,7 +14,7 @@ This Source Code Form is subject to the terms of the Mozilla Public License, v. 
 The user guide can be found in the documentation directory of the CommonAPI-D-Bus-Tools project as AsciiDoc document. A pdf version can be found at https://github.com/GENIVI/capicxx-dbus-tools/releases.
 
 ##### Further information
-https://genivi.github.io/capicxx-core-tools/
+https://covesa.github.io/capicxx-core-tools/
 
 ##### Build Instructions for Linux
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ### CommonAPI C++ D-Bus Runtime
 
 ##### Copyright
-Copyright (C) 2016-2020, Bayerische Motoren Werke Aktiengesellschaft (BMW AG).
-Copyright (C) 2016-2020, GENIVI Alliance, Inc.
+Copyright (C) 2016-2017, Bayerische Motoren Werke Aktiengesellschaft (BMW AG).
+Copyright (C) 2016-2017, GENIVI Alliance, Inc.
 
 This file is part of GENIVI Project IPC Common API C++.
 Contributions are licensed to the GENIVI Alliance under one or more Contribution License Agreements or MPL 2.0.

--- a/cmake/CommonAPI-DBusConfig.cmake.in
+++ b/cmake/CommonAPI-DBusConfig.cmake.in
@@ -1,13 +1,26 @@
 # - Config file for the CommonAPI-DBus package
-# It defines the following variables
-#  COMMONAPI_DBUS_INCLUDE_DIRS - include directories for CommonAPI-DBus
+# Exports the following targets:
+#   CommonAPI-DBus - CMake target for CommonAPI DBus
+# Additionally, the following variables are defined:
+#   COMMONAPI_DBUS_VERSION - The CommonAPI-DBus version number
+
+# Dependencies
+include(CMakeFindDependencyMacro)
+find_dependency(CommonAPI)
+
+if(NOT TARGET dbus-1)
+    # the DBus1 CMake config is not double-include safe
+    find_dependency(DBus1)
+endif()
 
 # Compute paths
 get_filename_component(COMMONAPI_DBUS_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
-set(COMMONAPI_DBUS_INCLUDE_DIRS "@CONF_INCLUDE_DIRS@")
 
 # Our library dependencies (contains definitions for IMPORTED targets)
 include("${COMMONAPI_DBUS_CMAKE_DIR}/CommonAPI-DBusTargets.cmake")
+
+# Legacy variable, kept for compatibility
+get_target_property(COMMONAPI_DBUS_INCLUDE_DIRS CommonAPI-DBus INTERFACE_INCLUDE_DIRECTORIES)
 
 set(COMMONAPI_DBUS_VERSION @PACKAGE_VERSION@)
 set(COMMONAPI_DBUS_VERSION_STRING "@PACKAGE_VERSION@")

--- a/include/CommonAPI/DBus/DBusInputStream.hpp
+++ b/include/CommonAPI/DBus/DBusInputStream.hpp
@@ -497,7 +497,8 @@ private:
                                  !is_std_vector<Type_>::value &&
                                  !is_std_unordered_map<Type_>::value), int>::type = 0>
     COMMONAPI_EXPORT void alignVector() {
-        if (4 < sizeof(Type_)) align(8);
+        if (4 < sizeof(Type_) || std::is_same<Type_, float>::value)
+            align(8);
     }
 
     template<typename Type_,

--- a/include/CommonAPI/DBus/DBusOutputStream.hpp
+++ b/include/CommonAPI/DBus/DBusOutputStream.hpp
@@ -373,7 +373,8 @@ private:
                                  !is_std_vector<Type_>::value &&
                                  !is_std_unordered_map<Type_>::value), int>::type = 0>
     COMMONAPI_EXPORT void alignVector() {
-        if (4 < sizeof(Type_)) align(8);
+        if (4 < sizeof(Type_) || std::is_same<Type_, float>::value)
+            align(8);
     }
 
     template<typename Type_,

--- a/include/CommonAPI/DBus/DBusProxyHelper.hpp
+++ b/include/CommonAPI/DBus/DBusProxyHelper.hpp
@@ -274,8 +274,6 @@ struct DBusProxyHelper<In_<DBusInputStream, DBusOutputStream, InArgs_...>,
                     }
                 } else {
                     //create error message and push it directly to the connection
-                    unsigned int dummySerial = 999;
-                    _message.setSerial(dummySerial);   //set dummy serial
                     if (*sharedDbusMessageReplyAsyncHandler) {
                         DBusMessage errorMessage = _message.createMethodError(DBUS_ERROR_UNKNOWN_METHOD);
                         _proxy.getDBusConnection()->pushDBusMessageReplyToMainLoop(errorMessage,
@@ -521,8 +519,6 @@ struct DBusProxyHelper<In_<DBusInputStream, DBusOutputStream, InArgs_...>,
                     }
                 } else {
                     //create error message and push it directly to the connection
-                    unsigned int dummySerial = 999;
-                    _message.setSerial(dummySerial);   //set dummy serial
                     if (*sharedDbusMessageReplyAsyncHandler) {
                         DBusMessage errorMessage = _message.createMethodError(DBUS_ERROR_UNKNOWN_METHOD);
                         _proxy.getDBusConnection()->pushDBusMessageReplyToMainLoop(errorMessage,

--- a/src/CommonAPI/DBus/DBusClientId.cpp
+++ b/src/CommonAPI/DBus/DBusClientId.cpp
@@ -55,15 +55,15 @@ DBusMessage DBusClientId::createMessage(const std::string objectPath, const std:
     DBusMessage returnMessage = DBusMessage::createSignal(objectPath, interfaceName, signalName);
     returnMessage.setDestination(dbusId_.c_str());
 
-    return(returnMessage);
+    return (returnMessage);
 }
 
 uid_t DBusClientId::getUid() const {
-    return (0);
+    return (0xFFFFFFFF);
 }
 
 gid_t DBusClientId::getGid() const {
-    return (0);
+    return (0xFFFFFFFF);
 }
 
 } // namespace DBus

--- a/src/CommonAPI/DBus/DBusMessage.cpp
+++ b/src/CommonAPI/DBus/DBusMessage.cpp
@@ -115,6 +115,10 @@ DBusMessage
 DBusMessage::createMethodError(
     const std::string &_code, const std::string &_signature, const std::string &_info) const {
 
+    if (getSerial() == 0) {
+        COMMONAPI_WARNING(std::string(__FUNCTION__), " getSerial() is 0, setting dummy serial to: ", UINT32_MAX);
+        setSerial(UINT32_MAX);
+    }
     ::DBusMessage *methodError
           = dbus_message_new_error(message_, _code.c_str(), _info.c_str());
     if (NULL == methodError) {

--- a/src/test/CMakeLists.txt
+++ b/src/test/CMakeLists.txt
@@ -7,26 +7,22 @@ cmake_minimum_required (VERSION 2.8.1)
 
 pkg_check_modules(GLIB glib-2.0)
 
+# Do not put the build path into RPATH as we are going to install the tests
+# Correct soulution would be to provide an install target
+set(CMAKE_SKIP_BUILD_RPATH TRUE)
+
 include_directories(.
        ./src-gen/core
        ./src-gen/dbus
        ${COMMONAPI_INCLUDE_DIRS}
-       ${DBus_INCLUDE_DIRS}
        ${gtest_SOURCE_DIR}/include
        ${GLIB_INCLUDE_DIRS}
 )
 
-if ("${USE_INSTALLED_DBUS}" STREQUAL "OFF")
-    set(DBus_LDFLAGS dbus-1)
-    link_directories(
-        ${DBus_INCLUDE_DIRS}/dbus/.libs
-    )
-endif()
-
 if (MSVC)
- set(TEST_LINK_LIBRARIES ${DBus_LDFLAGS} CommonAPI-DBus CommonAPI gtest )
+ set(TEST_LINK_LIBRARIES CommonAPI-DBus CommonAPI gtest )
 else()
- set(TEST_LINK_LIBRARIES -Wl,--no-as-needed CommonAPI-DBus -Wl,--as-needed CommonAPI ${DBus_LDFLAGS} ${DL_LIBRARY} gtest ${PTHREAD_LIBRARY})
+ set(TEST_LINK_LIBRARIES -Wl,--no-as-needed CommonAPI-DBus -Wl,--as-needed CommonAPI ${DL_LIBRARY} gtest ${PTHREAD_LIBRARY})
 endif()
 
 ##############################################################################


### PR DESCRIPTION
- Fixed crash in dbus_message_set_reply_serial()
- Update the object cache on the result of getManagedObjectsAsync
- Adapt to CommonAPI v3.2.2
- Fix float array serialization